### PR TITLE
version up + critical fix

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   influxdb:
-    image: influxdb:1.7.3
+    image: influxdb:1.7.10
     container_name: metrics_influxdb
     hostname: influxdb
     volumes:
@@ -21,7 +21,7 @@ services:
 #      - 8888:8888
 
   grafana:
-    image: grafana/grafana:5.4.3
+    image: grafana/grafana:6.7.2
     container_name: metrics_grafana
     hostname: grafana
     volumes:
@@ -30,7 +30,7 @@ services:
       - 3000:3000
 
   telegraf:
-    image: telegraf:1.9.4
+    image: telegraf:1.12.6
     container_name: metrics_telegraf
     hostname: telegraf
     volumes:

--- a/docker/telegraf/telegraf.conf
+++ b/docker/telegraf/telegraf.conf
@@ -15,7 +15,7 @@
 [[outputs.influxdb]]
   urls = ["http://influxdb:8086"]
   database = "metrics"
-  retention_policy = "duration_3d_precision_1s"
+  retention_policy = "1s"
   write_consistency = "any"
   timeout = "5s"
 


### PR DESCRIPTION
- version up of TIG stack
- fix critical bug in Telegraf config

Given cutting edge versions of TIG stack, telegraf was failing with an error due to a bug in its config. With current versions the problem was not in place. This PR is a premature fix of the problem, before it practically hits production. 